### PR TITLE
Delete ignored key from config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,10 +7,6 @@
   "deprecated": [
 
   ],
-  "ignored": [
-    "bin",
-    "img"
-  ],
   "foregone": [
 
   ],


### PR DESCRIPTION
Since the exercise implementations are all in the exercises directory
we no longer need to ignore any non-exercise directories in the root
of the track.

See https://github.com/exercism/meta/issues/3 for context.